### PR TITLE
Update rp14 scraper

### DIFF
--- a/scraper/rp14/scraper.js
+++ b/scraper/rp14/scraper.js
@@ -94,9 +94,6 @@ exports.scrape = function (callback) {
 			sessionList.forEach(function (session) {
 				session = session.session;
 
-				// console.log(speakerMap);
-
-
 				var entry = {
 					'id': 'rp14-session-' + session.nid,
 					'title': session.title,
@@ -116,7 +113,7 @@ exports.scrape = function (callback) {
 					'enclosures': [],
 					'links': []
 				}
-				// console.log("session roomid" + entry);
+
 				addEntry('session', entry);
 			})
 


### PR DESCRIPTION
As the date seems to be updated daily now, I mage a few improvements to the rp14 scraper:
- Locations are now parsed and added to session object (if the location exists in the data, that is)
- Start time and date are parsed now
- Speakers are added to session object
- Day objects are now added to sessions as needed
- Updated the `id` property of the day to resemble the id property used in rp13 and avoid collisions.
