### PR TITLE
#rp14: Update colors for tracks and add new locations

### DIFF
--- a/scraper/rp14/scraper.js
+++ b/scraper/rp14/scraper.js
@@ -5,12 +5,12 @@ var path = require('path');
 
 var allTracks = {
 	'Business & Innovation':  { id:'business-innovation', label_de:'Business & Innovation',  label_en:'Business & Innovation', color:[194.0, 56.0, 24.0, 1.0] },
-	'Science & Technology':   { id:'science-technology',  label_de:'Wissenschaft & Technik', label_en:'Science & Technology' , color:[0.0, 0.0, 0.0, 1.0] },
+	'Science & Technology':   { id:'science-technology',  label_de:'Wissenschaft & Technik', label_en:'Science & Technology' , color:[168.0, 146.0, 24.0, 1.0] },
 	'Politics & Society':     { id:'politics-society',    label_de:'Politik & Gesellschaft', label_en:'Politics & Society'   , color:[111.0, 79.0, 132.0, 1.0] },
 	'Research & Education':   { id:'research-education',  label_de:'Forschung & Bildung',    label_en:'Research & Education' , color:[0.0, 0.0, 0.0, 1.0] },
 	'Culture':                { id:'culture',             label_de:'Kultur',                 label_en:'Culture'              , color:[193.0, 117.0, 28.0, 1.0] },
 	'Media':                  { id:'media',               label_de:'Medien',                 label_en:'Media'                , color:[78.0, 144.0, 178.0, 1.0] },
-	're:publica':             { id:'republica',           label_de:'re:publica',             label_en:'re:publica'           , color:[0.0, 0.0, 0.0, 1.0] },
+	're:publica':             { id:'republica',           label_de:'re:publica',             label_en:'re:publica'           , color:[102.0, 156.0, 44.0, 1.0] },
 	're:campaign':            { id:'recampaign',          label_de:'re:campaign',            label_en:'re:campaign'          , color:[0.0, 0.0, 0.0, 1.0] },
 	'Other':                  { id:'other',               label_de:'Other',                  label_en:'Other'                , color:[101.0, 156.0, 45.0, 1.0] }
 }


### PR DESCRIPTION
Update for the #rp14 scraper
- Add `re/connect` and `backyard` as locations
- Update colors for `Science & Technology` and `re:publica` tracks
- Ensure that unknown locations encountered by the scraper will be ordered at the end
