### PR TITLE
Scrape recordings from YouTube

### DIFF
--- a/scraper/rp14/scraper.js
+++ b/scraper/rp14/scraper.js
@@ -113,7 +113,7 @@ exports.scrape = function (callback) {
 					'id': 'rp14-speaker-'+speaker.uid,
 					'name': speaker.label,
 					'photo': speaker.image,
-					'url': eventURLPrefix + speaker.uri,
+					'url': eventURLPrefix + '/' + speaker.uri,
 					'biography': speaker.description_short,
 					'organization': speaker.org,
 					'organization_url': speaker.org_uri,


### PR DESCRIPTION
Added youtube videos to the rp14 scraper.
- The pagination of the youtube feed is hardcoded at the moment, but it works. 
- Also remove the double `/` in the permalinks. 

Association of the youtube videos is currently done via regexp matching the permalink in the video description. As the videos are uploaded automatically this should be reliable enough. Worst case a video is not matched.
